### PR TITLE
Fix window being too small on high-DPI displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to md2loop are documented here.
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Releases before 1.2.1 are documented on the
+[GitHub releases page](https://github.com/trsdn/md2loop-windows/releases).
+
+## [1.2.1] - 2026-08-18
+
+### Fixed
+
+- The main window came up far too small on high-DPI displays and clipped the
+  page content. `AppWindow.Resize` takes physical pixels rather than DIPs, so
+  the hard-coded size produced a window of only 206x160 DIPs at 175% scaling.
+  The window is now sized from the current rasterization scale, so it is
+  360x300 DIPs on every display scale.
+- The window is given a DPI-scaled minimum size, so it can no longer be
+  resized small enough to clip its own content, and it is re-checked when the
+  window moves to a monitor with a different scale factor.
+- The window is now centered when it first appears.
+- `installer/build.ps1` did not pass `/DMyAppArm64` to Inno Setup, so local
+  ARM64 builds produced an installer labelled `win-x64` that refused to install
+  on ARM64. It also did not pass `-p:Version`, so locally built binaries were
+  always stamped 1.0.0.
+
+### Changed
+
+- The window is 300 DIPs tall instead of 280, so the post-conversion feedback
+  row fits without clipping.
+
+[1.2.1]: https://github.com/trsdn/md2loop-windows/releases/tag/v1.2.1

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -34,6 +34,7 @@ dotnet publish "$root\md2loop\md2loop.csproj" `
     -c Release `
     -r "win-$Architecture" `
     --self-contained true `
+    -p:Version=$Version `
     -p:PublishSingleFile=true `
     -p:PublishTrimmed=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
@@ -49,15 +50,26 @@ $iscc = "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe"
 if (-not (Test-Path $iscc)) {
     $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
 }
+$installerPath = $null
 if (-not (Test-Path $iscc)) {
     Write-Host "⚠️  Inno Setup not found. Skipping installer, creating ZIP only." -ForegroundColor Yellow
 } else {
     Write-Host "🏗️  Building installer..." -ForegroundColor Yellow
-    & $iscc "/DMyAppVersion=$Version" "$root\installer\md2loop.iss"
+
+    # The .iss defaults to win-x64; ARM64 builds must opt in so the installer is
+    # named correctly and refuses to install on the wrong architecture.
+    $isccArgs = @("/DMyAppVersion=$Version")
+    if ($Architecture -eq "arm64") {
+        $isccArgs += "/DMyAppArm64"
+    }
+    $isccArgs += "$root\installer\md2loop.iss"
+
+    & $iscc @isccArgs
     if ($LASTEXITCODE -ne 0) {
         Write-Host "❌ Installer build failed!" -ForegroundColor Red
         exit 1
     }
+    $installerPath = "$distDir\md2loop-setup-$Version-win-$Architecture.exe"
 }
 
 # Also create portable ZIP
@@ -65,5 +77,7 @@ $zipPath = "$distDir\md2loop-win-$Architecture-v$Version.zip"
 Compress-Archive -Path "$publishDir\*" -DestinationPath $zipPath
 Write-Host ""
 Write-Host "✅ Build complete!" -ForegroundColor Green
-Write-Host "   Installer: $distDir\md2loop-setup-$Version.exe" -ForegroundColor White
+if ($installerPath) {
+    Write-Host "   Installer: $installerPath" -ForegroundColor White
+}
 Write-Host "   Portable:  $zipPath" -ForegroundColor White

--- a/md2loop/MainWindow.xaml.cs
+++ b/md2loop/MainWindow.xaml.cs
@@ -1,9 +1,29 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using WinRT.Interop;
 
 namespace md2loop;
 
 public sealed partial class MainWindow : Window
 {
+    // Design size in device-independent pixels (DIPs) at 96 DPI.
+    private const int BaseWidthDips = 360;
+    private const int BaseHeightDips = 300;
+
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOZORDER = 0x0004;
+    private const uint SWP_NOACTIVATE = 0x0010;
+
+    private readonly IntPtr _hwnd;
+    private DispatcherQueueTimer? _settleTimer;
+    private int _settleTicks;
+    private bool _initialSizeApplied;
+    private bool _centered;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -12,8 +32,147 @@ public sealed partial class MainWindow : Window
         SetTitleBar(AppTitleBar);
 
         AppWindow.SetIcon("Assets/AppIcon.ico");
-        AppWindow.Resize(new Windows.Graphics.SizeInt32(360, 280));
+
+        _hwnd = WindowNative.GetWindowHandle(this);
 
         RootFrame.Navigate(typeof(MainPage));
+
+        RootFrame.Loaded += (_, _) =>
+        {
+            // The rasterization scale is only trustworthy once the XAML tree is live;
+            // GetDpiForWindow still reports 96 during construction and activation.
+            if (RootFrame.XamlRoot is { } xamlRoot)
+            {
+                xamlRoot.Changed += (_, _) => EnforceMinimumSize();
+            }
+
+            EnforceMinimumSize();
+            StartSettleTimer();
+        };
     }
+
+    /// <summary>
+    /// Windows finishes the initial per-monitor DPI transition shortly after the
+    /// content loads and rescales the window as part of it, which silently undoes
+    /// the size we just applied. Re-assert the size for a moment until it sticks.
+    /// </summary>
+    private void StartSettleTimer()
+    {
+        var queue = DispatcherQueue.GetForCurrentThread();
+        if (queue is null)
+        {
+            return;
+        }
+
+        _settleTimer = queue.CreateTimer();
+        _settleTimer.Interval = TimeSpan.FromMilliseconds(100);
+        _settleTimer.Tick += (timer, _) =>
+        {
+            EnforceMinimumSize();
+            if (++_settleTicks >= 10)
+            {
+                timer.Stop();
+                _settleTimer = null;
+            }
+        };
+        _settleTimer.Start();
+    }
+
+    private void EnforceMinimumSize()
+    {
+        var scale = GetScaleFactor();
+        var width = (int)Math.Round(BaseWidthDips * scale);
+        var height = (int)Math.Round(BaseHeightDips * scale);
+
+        if (AppWindow.Presenter is OverlappedPresenter presenter)
+        {
+            presenter.PreferredMinimumWidth = width;
+            presenter.PreferredMinimumHeight = height;
+        }
+
+        if (!GetWindowRect(_hwnd, out var rect))
+        {
+            return;
+        }
+
+        var currentWidth = rect.Right - rect.Left;
+        var currentHeight = rect.Bottom - rect.Top;
+
+        // The first pass applies the compact design size exactly. Later passes only
+        // grow, so a user who enlarged the window keeps their size while the window
+        // is still restored after the DPI transition rescales it.
+        if (_initialSizeApplied)
+        {
+            if (currentWidth >= width && currentHeight >= height)
+            {
+                return;
+            }
+
+            width = Math.Max(currentWidth, width);
+            height = Math.Max(currentHeight, height);
+        }
+        else if (currentWidth == width && currentHeight == height)
+        {
+            _initialSizeApplied = true;
+            return;
+        }
+
+        _initialSizeApplied = true;
+
+        // SetWindowPos is used instead of AppWindow.Resize because it is unambiguously
+        // in physical pixels and is not reinterpreted by the pending DPI transition.
+        SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, width, height,
+            SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+
+        if (!_centered)
+        {
+            _centered = true;
+            CenterOnDisplay();
+        }
+    }
+
+    private void CenterOnDisplay()
+    {
+        var display = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
+        if (display is null || !GetWindowRect(_hwnd, out var rect))
+        {
+            return;
+        }
+
+        var work = display.WorkArea;
+        var x = work.X + ((work.Width - (rect.Right - rect.Left)) / 2);
+        var y = work.Y + ((work.Height - (rect.Bottom - rect.Top)) / 2);
+        SetWindowPos(_hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    }
+
+    private double GetScaleFactor()
+    {
+        if (RootFrame.XamlRoot is { RasterizationScale: > 0 } xamlRoot)
+        {
+            return xamlRoot.RasterizationScale;
+        }
+
+        var dpi = GetDpiForWindow(_hwnd);
+        return dpi == 0 ? 1.0 : dpi / 96.0;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(IntPtr hwnd, IntPtr insertAfter, int x, int y, int cx, int cy, uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(IntPtr hwnd);
 }


### PR DESCRIPTION
## Why

On a high-DPI display the main window came up far too small and clipped the page content. `MainWindow` hard-coded `AppWindow.Resize(new SizeInt32(360, 280))`, but `AppWindow.Resize` and `OverlappedPresenter.PreferredMinimum*` take **physical pixels**, not DIPs. At 175% scaling that produced a window of only 206x160 DIPs.

## Approach

Window sizing is now derived from the actual scale factor rather than assuming 1.0:

- Scale comes from `XamlRoot.RasterizationScale` (falling back to `GetDpiForWindow`), applied on `Loaded` and re-applied on every `XamlRoot.Changed`, so moving to a monitor with a different scale factor is handled too.
- A DPI-scaled `PreferredMinimumWidth/Height` is set on the presenter so the layout cannot be dragged down into clipping.
- The first pass applies the compact design size exactly; later passes only grow the window, so a user who enlarged it keeps their size.
- The window is centered on first show.
- Design height went from 280 to 300 DIPs so the feedback row has space once a conversion runs.

## Non-obvious bits worth a look

Two things made the naive fix fail, and both are why the code looks more involved than "multiply by the scale":

1. `GetDpiForWindow` still reports 96 during the constructor **and** during the first `Activated` event, because Windows has not placed the window on its target monitor yet. Sizing in either place silently uses scale 1.0. Hence sizing on `Loaded` off `RasterizationScale`.
2. Windows completes the initial per-monitor DPI transition shortly *after* content load and rescales the window as part of it, silently undoing the size just applied. A short settle pass (10 ticks at 100 ms) re-asserts the size until it sticks. This is the part I would most like a second opinion on; it is a pragmatic workaround rather than handling `WM_DPICHANGED` via a window subclass, which would need more plumbing.

`SetWindowPos` is used instead of `AppWindow.Resize` because it is unambiguously in physical pixels and is not reinterpreted by the pending DPI transition.

## Verification

Measured on a 168 DPI (175%) display with a per-monitor-v2-aware probe:

| | physical | DIPs |
|---|---|---|
| before | 360x280 | 206x160 |
| after | 630x525 | 360x300 |

Size is stable when re-checked at 3s, 8s and 15s, the window centers exactly, and a screenshot of the live window confirms all content renders without clipping. Build is clean (0 warnings, 0 errors).

One measurement gotcha for anyone re-testing: `Process.MainWindowHandle` returns a phantom HWND for WinUI 3 apps, and a DPI-unaware probe process gets `GetWindowRect` results virtualized by 96/168. Enumerate for `WinUIDesktopWin32WindowClass` from a per-monitor-v2-aware process to get real numbers.