### PR TITLE
Fix duplicated content when converting nested lists

### DIFF
--- a/md2loop/HtmlToMarkdownConverter.cs
+++ b/md2loop/HtmlToMarkdownConverter.cs
@@ -183,7 +183,7 @@ public static partial class HtmlToMarkdownConverter
     private static void ConvertListItem(HtmlNode li, StringBuilder sb, int listDepth, ref int orderedIndex, bool ordered)
     {
         var indent = new string(' ', listDepth * 4);
-        var text = HtmlEntity.DeEntitize(li.InnerText).Trim();
+        var text = GetItemText(li);
 
         // Check for task list (Unicode checkboxes from Loop)
         if (text.StartsWith("☑"))
@@ -207,7 +207,7 @@ public static partial class HtmlToMarkdownConverter
         }
 
         // Handle nested lists
-        foreach (var child in li.ChildNodes.Where(c => c.Name is "ul" or "ol"))
+        foreach (var child in GetNestedLists(li))
         {
             int nestedIdx = 1;
             foreach (var nestedLi in child.ChildNodes.Where(c => c.Name == "li"))
@@ -216,6 +216,59 @@ public static partial class HtmlToMarkdownConverter
             }
         }
     }
+
+    /// <summary>
+    /// Text belonging to the list item itself. Nested lists are excluded because
+    /// they are emitted separately as indented items.
+    /// </summary>
+    private static string GetItemText(HtmlNode li)
+    {
+        var sb = new StringBuilder();
+        AppendTextOutsideNestedLists(li, sb);
+        return HtmlEntity.DeEntitize(sb.ToString()).Trim();
+    }
+
+    private static void AppendTextOutsideNestedLists(HtmlNode node, StringBuilder sb)
+    {
+        foreach (var child in node.ChildNodes)
+        {
+            if (child.NodeType == HtmlNodeType.Text)
+            {
+                sb.Append(child.InnerText);
+            }
+            else if (child.NodeType == HtmlNodeType.Element && !IsList(child))
+            {
+                AppendTextOutsideNestedLists(child, sb);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Nested lists, which may be wrapped in an intermediate element such as a
+    /// div or paragraph. Descends only through non-list elements so each list is
+    /// yielded once, at its outermost position.
+    /// </summary>
+    private static IEnumerable<HtmlNode> GetNestedLists(HtmlNode li)
+    {
+        foreach (var child in li.ChildNodes)
+        {
+            if (child.NodeType != HtmlNodeType.Element)
+                continue;
+
+            if (IsList(child))
+            {
+                yield return child;
+            }
+            else
+            {
+                foreach (var nested in GetNestedLists(child))
+                    yield return nested;
+            }
+        }
+    }
+
+    private static bool IsList(HtmlNode node)
+        => node.Name is "ul" or "ol";
 
     private static void ConvertTable(HtmlNode table, StringBuilder sb)
     {


### PR DESCRIPTION
Fixes #17.

## Problem

`ConvertListItem` took the item text from `li.InnerText`, which returns the concatenated text of **all** descendants — including nested `<ul>`/`<ol>`. Those nested lists were then walked separately and emitted again, so every nested list appeared twice.

## Change

- Item text is now collected from the nodes belonging to the item itself, skipping nested lists.
- Nested lists are gathered at their outermost position, descending through non-list wrappers, so a list wrapped in a `<div>` or `<p>` (common in editor-generated HTML) is found exactly once instead of being missed by the old direct-children-only lookup and duplicated into the parent text.

## Verification

Ran the converter against the pinned HtmlAgilityPack 1.11.72.

Input:
```html
<ul><li>Parent<ul><li>Child</li><li>Child2</li></ul></li><li>Second</li></ul>
```

Before:
```markdown
- ParentChildChild2
    - Child
    - Child2
- Second
```

After:
```markdown
- Parent
    - Child
    - Child2
- Second
```

Ordered lists behave the same way (`1. FirstInner` → `1. First`), and existing task-list and flat-list output is unchanged.

`dotnet build -c Release -r win-x64` succeeds with 0 warnings.

## Scope

Inline formatting inside list items is still flattened to plain text — that is the separate root cause tracked in #15 and is deliberately not addressed here.
