### PR TITLE
Keep inline formatting in list items and table cells

### DIFF
--- a/md2loop/HtmlToMarkdownConverter.cs
+++ b/md2loop/HtmlToMarkdownConverter.cs
@@ -218,30 +218,35 @@ public static partial class HtmlToMarkdownConverter
     }
 
     /// <summary>
-    /// Text belonging to the list item itself. Nested lists are excluded because
-    /// they are emitted separately as indented items.
+    /// Markdown for the list item's own content. Nested lists are excluded
+    /// because they are emitted separately as indented items.
     /// </summary>
     private static string GetItemText(HtmlNode li)
     {
+        // Convert a copy with the nested lists detached so inline elements still
+        // run through the normal conversion pipeline and keep their formatting.
+        var clone = li.Clone();
+        foreach (var nested in GetNestedLists(clone).ToList())
+            nested.Remove();
+
         var sb = new StringBuilder();
-        AppendTextOutsideNestedLists(li, sb);
-        return HtmlEntity.DeEntitize(sb.ToString()).Trim();
+        ConvertChildren(clone, sb, listDepth: 0, orderedIndex: 0, inPre: false);
+        return NormalizeSingleLine(sb.ToString());
     }
 
-    private static void AppendTextOutsideNestedLists(HtmlNode node, StringBuilder sb)
+    /// <summary>
+    /// Markdown for a single table cell, forced onto one line so the pipe table
+    /// stays well formed.
+    /// </summary>
+    private static string GetCellText(HtmlNode cell)
     {
-        foreach (var child in node.ChildNodes)
-        {
-            if (child.NodeType == HtmlNodeType.Text)
-            {
-                sb.Append(child.InnerText);
-            }
-            else if (child.NodeType == HtmlNodeType.Element && !IsList(child))
-            {
-                AppendTextOutsideNestedLists(child, sb);
-            }
-        }
+        var sb = new StringBuilder();
+        ConvertChildren(cell, sb, listDepth: 0, orderedIndex: 0, inPre: false);
+        return NormalizeSingleLine(sb.ToString()).Replace("|", "\\|");
     }
+
+    private static string NormalizeSingleLine(string value)
+        => CollapseWhitespaceRegex().Replace(value, " ").Trim();
 
     /// <summary>
     /// Nested lists, which may be wrapped in an intermediate element such as a
@@ -279,7 +284,7 @@ public static partial class HtmlToMarkdownConverter
         {
             foreach (var tr in thead.SelectNodes("tr") ?? Enumerable.Empty<HtmlNode>())
             {
-                var cells = tr.SelectNodes("th|td")?.Select(c => HtmlEntity.DeEntitize(c.InnerText).Trim()).ToArray();
+                var cells = tr.SelectNodes("th|td")?.Select(GetCellText).ToArray();
                 if (cells != null) rows.Add(cells);
             }
         }
@@ -287,7 +292,7 @@ public static partial class HtmlToMarkdownConverter
         var tbody = table.SelectSingleNode("tbody") ?? table;
         foreach (var tr in tbody.SelectNodes("tr") ?? Enumerable.Empty<HtmlNode>())
         {
-            var cells = tr.SelectNodes("th|td")?.Select(c => HtmlEntity.DeEntitize(c.InnerText).Trim()).ToArray();
+            var cells = tr.SelectNodes("th|td")?.Select(GetCellText).ToArray();
             if (cells is { Length: > 0 }) rows.Add(cells);
         }
 


### PR DESCRIPTION
Fixes #15.

> **Stacked on #28** — based on `fix/17-nested-list-duplication`, so review that one first. The diff shown here is only this change once #28 merges.

## Problem

`ConvertListItem` and `ConvertTable` both read content via `InnerText`, which flattens all markup to plain text. The converter already handles `<strong>`, `<em>`, `<code>`, `<a>` and `<s>` properly — that pipeline was simply bypassed in the two places formatting appears most often.

## Change

- List items and table cells now go through `ConvertChildren`, the same path used everywhere else.
- List items convert a **copy** of the `<li>` with nested lists detached, so nested content is still emitted separately as indented items rather than being inlined.
- Item and cell text is collapsed onto a single line, so a cell containing `<br>` or block children can no longer break the pipe table across rows.
- `|` inside a cell is escaped as `\|`, which previously split the cell into two columns.

## Verification

Ran against the pinned HtmlAgilityPack 1.11.72.

| Input | Before | After |
|---|---|---|
| `<li>See <a href="…">docs</a> for <strong>details</strong></li>` | `- See docs for details` | `- See [docs](https://example.com) for **details**` |
| `<td><strong>Bold</strong></td>` | `\| Bold \|` | `\| **Bold** \|` |
| `<td>a\|b</td>` | `\| a\|b \|` (breaks the table) | `\| a\\\|b \|` |

Nested-list output from #28 is unchanged, and existing task-list detection (`☑`/`☐` prefix) still works because the prefix survives conversion.

`dotnet build -c Release -r win-x64` succeeds with 0 warnings.

## Scope

Text nodes are still emitted unescaped — tracked separately in #16.
