### PR TITLE
Escape Markdown syntax in converted text

### DIFF
--- a/md2loop/HtmlToMarkdownConverter.cs
+++ b/md2loop/HtmlToMarkdownConverter.cs
@@ -46,7 +46,7 @@ public static partial class HtmlToMarkdownConverter
             }
             else
             {
-                sb.Append(CollapseWhitespaceRegex().Replace(text, " "));
+                sb.Append(EscapeInline(CollapseWhitespaceRegex().Replace(text, " ")));
             }
             return;
         }
@@ -67,7 +67,9 @@ public static partial class HtmlToMarkdownConverter
                 break;
 
             case "p":
-                ConvertChildren(node, sb, listDepth, 0, false);
+                var paragraph = new StringBuilder();
+                ConvertChildren(node, paragraph, listDepth, 0, false);
+                sb.Append(EscapeLeadingBlockMarker(paragraph.ToString()));
                 sb.Append("\n\n");
                 break;
 
@@ -96,9 +98,15 @@ public static partial class HtmlToMarkdownConverter
                 }
                 else
                 {
-                    sb.Append('`');
-                    sb.Append(HtmlEntity.DeEntitize(node.InnerText));
-                    sb.Append('`');
+                    // The delimiter has to be longer than any backtick run inside.
+                    var inlineCode = HtmlEntity.DeEntitize(node.InnerText);
+                    var delimiter = new string('`', LongestBacktickRun(inlineCode) + 1);
+                    var padding = inlineCode.StartsWith('`') || inlineCode.EndsWith('`') ? " " : "";
+                    sb.Append(delimiter);
+                    sb.Append(padding);
+                    sb.Append(inlineCode);
+                    sb.Append(padding);
+                    sb.Append(delimiter);
                 }
                 break;
 
@@ -238,7 +246,7 @@ public static partial class HtmlToMarkdownConverter
 
         var sb = new StringBuilder();
         ConvertChildren(clone, sb, listDepth: 0, orderedIndex: 0, inPre: false);
-        return NormalizeSingleLine(sb.ToString());
+        return EscapeLeadingBlockMarker(NormalizeSingleLine(sb.ToString()));
     }
 
     /// <summary>
@@ -254,6 +262,71 @@ public static partial class HtmlToMarkdownConverter
 
     private static string NormalizeSingleLine(string value)
         => CollapseWhitespaceRegex().Replace(value, " ").Trim();
+
+    /// <summary>
+    /// Escapes characters in a text node that would otherwise be re-read as
+    /// inline Markdown syntax. Underscores are only escaped at word boundaries,
+    /// so identifiers such as file_name_here stay readable.
+    /// </summary>
+    private static string EscapeInline(string text)
+    {
+        if (text.Length == 0)
+            return text;
+
+        var sb = new StringBuilder(text.Length);
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            switch (c)
+            {
+                case '\\' or '`' or '*' or '[' or ']':
+                    sb.Append('\\').Append(c);
+                    break;
+
+                case '_' when IsWordBoundary(text, i):
+                    sb.Append("\\_");
+                    break;
+
+                case '~' when i + 1 < text.Length && text[i + 1] == '~':
+                    sb.Append("\\~\\~");
+                    i++;
+                    break;
+
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool IsWordBoundary(string text, int index)
+    {
+        var before = index > 0 && char.IsLetterOrDigit(text[index - 1]);
+        var after = index + 1 < text.Length && char.IsLetterOrDigit(text[index + 1]);
+        return !before || !after;
+    }
+
+    /// <summary>
+    /// Escapes a leading character that would turn a paragraph into a heading,
+    /// list item, blockquote or thematic break.
+    /// </summary>
+    private static string EscapeLeadingBlockMarker(string text)
+    {
+        var match = LeadingBlockMarkerRegex().Match(text);
+        if (!match.Success)
+            return text;
+
+        // An ordered marker is neutralised on its delimiter ("1\." ), because a
+        // backslash before a digit is not an escape sequence and would render.
+        var punct = match.Groups["punct"];
+        var escapeAt = punct.Success ? punct.Index : match.Groups["marker"].Index;
+
+        return string.Concat(text.AsSpan(0, escapeAt), "\\", text.AsSpan(escapeAt));
+    }
 
     private static int LongestBacktickRun(string value)
     {
@@ -357,6 +430,9 @@ public static partial class HtmlToMarkdownConverter
 
     [GeneratedRegex(@"language-(\S+)")]
     private static partial Regex LanguageClassRegex();
+
+    [GeneratedRegex(@"^\s{0,3}(?:\d+(?<punct>[.)])(?=\s|$)|(?<marker>#{1,6}(?=\s|$)|>|[-+](?=\s|$)|-{3,}\s*$|={3,}\s*$))")]
+    private static partial Regex LeadingBlockMarkerRegex();
 
     [GeneratedRegex(@"[\s]+")]
     private static partial Regex CollapseWhitespaceRegex();


### PR DESCRIPTION
Fixes #16.

> **Stacked on #30** (→ #29 → #28). Review those first.

## Problem

Text nodes went straight into the output with no escaping, so prose containing Markdown punctuation was re-read as formatting on the next render.

## Change

Three escaping passes, all skipped where content is already literal (`<pre>`, inline `<code>`, and URLs):

1. **Inline characters** — `\` `` ` `` `*` `[` `]` always; `~~` runs; `_` only at word boundaries.
2. **Leading block markers** — a paragraph or list item starting with `#`, `>`, `-`, `+`, an ordered marker, or a `---`/`===` run gets neutralised.
3. **Inline code delimiters** — sized longer than the longest backtick run inside, with padding spaces when the content starts or ends with a backtick.

Two deliberate refinements:

- **`_` is not escaped inside words.** `file_name_here` stays readable rather than becoming `file\_name\_here`; intra-word underscores do not open emphasis.
- **Ordered markers escape the delimiter, not the digit** — `1\. text`, not `\1. text`, because a backslash before a digit is not an escape sequence and would render literally.

## Verification

| Input | Before | After |
|---|---|---|
| `<p>… multiply 2 * 3 * 4</p>` | `2 * 3 * 4` | `2 \* 3 \* 4` |
| `<p># not a heading</p>` | `# not a heading` (renders as H1) | `\# not a heading` |
| `<p>1. not ordered</p>` | `1. not ordered` (renders as a list) | `1\. not ordered` |
| `<p>… file_name_here …</p>` | `file_name_here` | `file_name_here` (unchanged) |
| `<code>a ` b</code>` | `` `a ` b` `` (broken) | ` ``a ` b`` ` |
| `<p>call <code>a_b_c</code></p>` | `` `a_b_c` `` | `` `a_b_c` `` (unchanged) |

I also ran a full Markdown → HTML → Markdown round trip over a document with headings, emphasis, links, nested lists, tables, a blockquote and a fenced block: no content is corrupted or over-escaped.

`dotnet build -c Release -r win-x64` succeeds with 0 warnings.

## Note

That round trip surfaced three further pre-existing defects unrelated to escaping, filed separately as #32, #33 and #34.

