### PR TITLE
Render task list checkboxes through a renderer, not string replacement

### DIFF
--- a/md2loop/LoopHtmlConverter.cs
+++ b/md2loop/LoopHtmlConverter.cs
@@ -1,8 +1,7 @@
 using Markdig;
+using Markdig.Extensions.TaskLists;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
-using Markdig.Syntax;
-using Markdig.Syntax.Inlines;
 
 namespace md2loop;
 
@@ -22,9 +21,6 @@ public static class LoopHtmlConverter
 
         var document = Markdown.Parse(markdown, Pipeline);
 
-        // Transform task list items to use Unicode checkboxes
-        TransformTaskLists(document);
-
         using var writer = new StringWriter();
         var renderer = new HtmlRenderer(writer)
         {
@@ -33,14 +29,15 @@ public static class LoopHtmlConverter
             EnableHtmlForInline = true
         };
         Pipeline.Setup(renderer);
+
+        // Loop does not render <input type="checkbox">, so task list items are
+        // written as Unicode checkboxes instead.
+        renderer.ObjectRenderers.Replace<HtmlTaskListRenderer>(new UnicodeTaskListRenderer());
+
         renderer.Render(document);
         writer.Flush();
 
         var html = writer.ToString();
-
-        // Post-process: replace checkbox inputs with Unicode chars for Loop compatibility
-        html = html.Replace("<input checked=\"\" disabled=\"\" type=\"checkbox\" /> ", "☑ ");
-        html = html.Replace("<input disabled=\"\" type=\"checkbox\" /> ", "☐ ");
 
         // Remove CSS classes that Markdig adds
         html = System.Text.RegularExpressions.Regex.Replace(html, @"\s*class=""[^""]*""", "");
@@ -48,26 +45,11 @@ public static class LoopHtmlConverter
         return html.Trim();
     }
 
-    private static void TransformTaskLists(MarkdownDocument document)
+    private sealed class UnicodeTaskListRenderer : HtmlObjectRenderer<TaskList>
     {
-        foreach (var block in document.Descendants())
+        protected override void Write(HtmlRenderer renderer, TaskList obj)
         {
-            if (block is not ListItemBlock listItem) continue;
-            if (listItem.Count == 0) continue;
-
-            var firstBlock = listItem[0];
-            if (firstBlock is not ParagraphBlock paragraph) continue;
-            if (paragraph.Inline?.FirstChild is not LiteralInline literal) continue;
-
-            var content = literal.Content.ToString();
-            if (content.StartsWith("[x] ") || content.StartsWith("[X] "))
-            {
-                literal.Content = new Markdig.Helpers.StringSlice("☑ " + content[4..]);
-            }
-            else if (content.StartsWith("[ ] "))
-            {
-                literal.Content = new Markdig.Helpers.StringSlice("☐ " + content[4..]);
-            }
+            renderer.Write(obj.Checked ? "☑" : "☐");
         }
     }
 }


### PR DESCRIPTION
Fixes #21.

> Independent of the `HtmlToMarkdownConverter` stack (#28 → #29 → #30 → #31) — branches from `master` and touches only `LoopHtmlConverter.cs`.

## This is a live output bug, not just fragility

The Unicode checkbox substitution matched literal strings Markdig 0.38.0 does not emit.

Actual Markdig output:
```html
<li><input disabled="disabled" type="checkbox" checked="checked" /> done</li>
```

What the code looked for:
```csharp
html.Replace("<input checked=\"\" disabled=\"\" type=\"checkbox\" /> ", "☑ ");
```

Attribute order *and* attribute values both differ, so neither replacement ever fired. **Task lists have been pasting raw `<input type="checkbox">` elements into Loop**, which is exactly what the Unicode workaround exists to avoid.

## Change

- Replace Markdig's `HtmlTaskListRenderer` with a small renderer that writes `☑`/`☐`. Output no longer depends on attribute order, spacing or self-closing style.
- Delete `TransformTaskLists`. It looked for a `LiteralInline` starting with `"[x] "`, but `UseAdvancedExtensions()` enables the TaskList extension, which parses `[x]` into a `TaskList` inline during parsing — so the method never matched anything.

## Verification

| Input | Before | After |
|---|---|---|
| `- [x] done` | `<li><input disabled="disabled" type="checkbox" checked="checked" /> done</li>` | `<li>☑ done</li>` |
| `- [ ] todo` | `<li><input disabled="disabled" type="checkbox" /> todo</li>` | `<li>☐ todo</li>` |
| nested task lists | raw inputs | `☑`/`☐` at both levels |
| `- a` / `- b` (plain list) | unchanged | unchanged |

Full round trip `- [x] done task` → HTML → Markdown now returns `- [x] done task`. Previously the state was lost entirely, because `HtmlToMarkdownConverter` looks for the `☑` prefix that was never produced.

`dotnet build -c Release -r win-x64` succeeds with 0 warnings.

## Scope

The blanket `class` stripping in the same method is a separate defect (it also removes `language-*` from code blocks) — filed as #34.
