### PR TITLE
Stop misdetecting Markdown that mentions HTML

### DIFF
--- a/md2loop/ClipboardContentDetector.cs
+++ b/md2loop/ClipboardContentDetector.cs
@@ -65,8 +65,6 @@ public static partial class ClipboardContentDetector
             return 0;
 
         var trimmed = text.Trim();
-        if (ContainsHTML(trimmed))
-            return 0;
 
         var lines = trimmed.ReplaceLineEndings("\n").Split('\n');
         var score = 0;
@@ -87,7 +85,22 @@ public static partial class ClipboardContentDetector
         if (ItalicRegex().IsMatch(trimmed)) score += 3;
         if (StrikethroughRegex().IsMatch(trimmed)) score += 3;
 
+        // Markdown may legitimately embed raw HTML, and technical writing often
+        // mentions tags inside code. Only markup outside code counts against the
+        // text, and it weighs against the other signals rather than vetoing them.
+        if (ContainsHTML(RemoveCode(trimmed))) score -= 6;
+
         return score;
+    }
+
+    /// <summary>
+    /// Strips fenced blocks and inline code spans, where angle brackets are
+    /// content rather than markup.
+    /// </summary>
+    private static string RemoveCode(string text)
+    {
+        var withoutFences = FencedBlockRegex().Replace(text, "\n");
+        return InlineCodeRegex().Replace(withoutFences, " ");
     }
 
     private static int GetRichTextScore(string html)
@@ -167,6 +180,9 @@ public static partial class ClipboardContentDetector
 
     [GeneratedRegex(@"`[^`\n]+`")]
     private static partial Regex InlineCodeRegex();
+
+    [GeneratedRegex(@"(```|~~~)[\s\S]*?\1")]
+    private static partial Regex FencedBlockRegex();
 
     [GeneratedRegex(@"(\*\*|__)(?=\S)(.+?)(?<=\S)\1")]
     private static partial Regex BoldRegex();


### PR DESCRIPTION
Fixes #14.

> Independent PR — branches from `master`, touches only `ClipboardContentDetector.cs`.

## Problem

`GetMarkdownScore` vetoed the entire score on any HTML-looking tag:

```csharp
if (ContainsHTML(trimmed))
    return 0;
```

This only bites when the clipboard carries **both** text and HTML — which is exactly what editors and browsers publish. So Markdown that merely *mentions* a tag was classified as rich text, and `Ctrl+Enter` ran HTML → Markdown on a document that was already Markdown.

## Change

- Markup inside fenced blocks and inline code is ignored, since angle brackets there are content, not markup.
- Remaining raw HTML is a **penalty (-6)** weighed against the other signals, not an absolute veto. Markdown that embeds a little raw HTML still wins on structure; text that genuinely *is* HTML still scores low and stays rich text.

## Verification

All cases below have the same syntax-highlighted editor HTML on the clipboard alongside the text, which is what triggers the bug.

| Clipboard text | Before | After |
|---|---|---|
| `# Title` + list + `**bold**` | `Markdown` | `Markdown` |
| `# Layout` + list + `` `<div class="card">` `` | **`RichText`** ❌ | `Markdown` ✅ |
| `# Title` + list + fenced ` ```html ` block | **`RichText`** ❌ | `Markdown` ✅ |
| `<h1>Hi</h1><p>there</p>` (HTML source as text) | `RichText` | `RichText` |
| Word paste: plain prose text + semantic HTML | `RichText` | `RichText` |
| HTML only, no text | `RichText` | `RichText` |
| empty | `Unknown` | `Unknown` |

No regressions: the two cases that must stay `RichText` still do, including a paste whose plain-text side has no Markdown syntax at all.

`dotnet build -c Release -r win-x64` succeeds with 0 warnings.
