### PR TITLE
Use clipboard change events instead of polling every second

### DIFF
--- a/md2loop/ClipboardManager.cs
+++ b/md2loop/ClipboardManager.cs
@@ -3,13 +3,32 @@ using Windows.ApplicationModel.DataTransfer;
 namespace md2loop;
 
 /// <summary>
+/// A point-in-time view of the clipboard.
+/// </summary>
+public readonly record struct ClipboardSnapshot(string? Text, string? Html, string? Rtf, bool IsExcluded)
+{
+    /// <summary>
+    /// Content the source app asked monitoring tools not to process.
+    /// </summary>
+    public static ClipboardSnapshot Excluded { get; } = new(null, null, null, true);
+}
+
+/// <summary>
 /// Windows clipboard operations for reading and writing HTML/RTF/text content.
 /// </summary>
 public static class ClipboardManager
 {
-    public static async Task<(string? Text, string? Html, string? Rtf)> ReadAsync()
+    // Set by password managers and similar apps to opt out of clipboard monitoring.
+    private const string ExcludeFromMonitoringFormat = "ExcludeClipboardContentFromMonitorProcessing";
+    private const string CanIncludeInHistoryProperty = "CanIncludeInClipboardHistory";
+
+    public static async Task<ClipboardSnapshot> ReadAsync()
     {
         var content = Clipboard.GetContent();
+
+        if (IsExcludedFromMonitoring(content))
+            return ClipboardSnapshot.Excluded;
+
         string? text = null;
         string? html = null;
         string? rtf = null;
@@ -32,7 +51,21 @@ public static class ClipboardManager
             rtf = await content.GetRtfAsync();
         }
 
-        return (text, html, rtf);
+        return new ClipboardSnapshot(text, html, rtf, IsExcluded: false);
+    }
+
+    /// <summary>
+    /// Whether the source app marked the content as private. Such content is not
+    /// read at all, so passwords and similar secrets never enter this process.
+    /// </summary>
+    private static bool IsExcludedFromMonitoring(DataPackageView content)
+    {
+        if (content.Contains(ExcludeFromMonitoringFormat))
+            return true;
+
+        return content.Properties.TryGetValue(CanIncludeInHistoryProperty, out var value)
+            && value is bool canInclude
+            && !canInclude;
     }
 
     /// <summary>

--- a/md2loop/MainPage.xaml.cs
+++ b/md2loop/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -11,9 +12,9 @@ public sealed partial class MainPage : Page
     private string? _clipboardText;
     private string? _clipboardHtml;
     private string? _clipboardRtf;
-    private DispatcherTimer? _timer;
     private DispatcherTimer? _feedbackTimer;
-    private bool _isPolling;
+    private bool _isReading;
+    private bool _isSubscribed;
 
     public MainPage()
     {
@@ -34,33 +35,60 @@ public sealed partial class MainPage : Page
 
     private void Page_Loaded(object sender, RoutedEventArgs e)
     {
-        if (_timer is not null)
-            return;
+        if (!_isSubscribed)
+        {
+            Clipboard.ContentChanged += OnClipboardContentChanged;
+            _isSubscribed = true;
+        }
 
-        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        _timer.Tick += async (_, _) => await PollClipboardAsync();
-        _timer.Start();
-
-        _ = PollClipboardAsync();
+        _ = RefreshAsync();
     }
 
     private void Page_Unloaded(object sender, RoutedEventArgs e)
     {
-        _timer?.Stop();
-        _timer = null;
+        if (_isSubscribed)
+        {
+            Clipboard.ContentChanged -= OnClipboardContentChanged;
+            _isSubscribed = false;
+        }
+
         _feedbackTimer?.Stop();
         _feedbackTimer = null;
     }
 
-    private async Task PollClipboardAsync()
+    /// <summary>
+    /// Re-reads the clipboard when the window is activated. ContentChanged is not
+    /// always delivered to a desktop app that is not in the foreground, so this
+    /// covers changes made while another app had focus.
+    /// </summary>
+    public void OnWindowActivated() => _ = RefreshAsync();
+
+    private void OnClipboardContentChanged(object? sender, object e)
     {
-        if (_isPolling)
+        // The event does not necessarily arrive on the UI thread.
+        DispatcherQueue.TryEnqueue(() => _ = RefreshAsync());
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (_isReading)
             return;
 
-        _isPolling = true;
+        _isReading = true;
         try
         {
-            var (text, html, rtf) = await ClipboardManager.ReadAsync();
+            var snapshot = await ClipboardManager.ReadAsync();
+
+            if (snapshot.IsExcluded)
+            {
+                ShowClipboardExcluded();
+                return;
+            }
+
+            var text = snapshot.Text;
+            var html = snapshot.Html;
+            var rtf = snapshot.Rtf;
+
             _clipboardText = text;
             _clipboardHtml = html;
             _clipboardRtf = rtf;
@@ -106,23 +134,40 @@ public sealed partial class MainPage : Page
         }
         finally
         {
-            _isPolling = false;
+            _isReading = false;
         }
     }
 
     private void ShowClipboardUnavailable()
     {
-        _currentMode = ClipboardMode.Unknown;
-        _clipboardText = null;
-        _clipboardHtml = null;
-        _clipboardRtf = null;
+        ResetClipboardState();
         ClipboardLengthText.Text = "Unavailable";
         ModeIcon.Glyph = "\uE7BA";
         ModeIcon.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray);
         ModeText.Text = "Clipboard is temporarily busy";
-        ShortcutText.Text = "Will retry automatically";
+        ShortcutText.Text = "Copy again or reactivate the window";
         RichTextButton.IsEnabled = false;
         MarkdownButton.IsEnabled = false;
+    }
+
+    private void ShowClipboardExcluded()
+    {
+        ResetClipboardState();
+        ClipboardLengthText.Text = "Private";
+        ModeIcon.Glyph = "\uE72E"; // Lock
+        ModeIcon.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray);
+        ModeText.Text = "Content is marked private";
+        ShortcutText.Text = "This content was not read";
+        RichTextButton.IsEnabled = false;
+        MarkdownButton.IsEnabled = false;
+    }
+
+    private void ResetClipboardState()
+    {
+        _currentMode = ClipboardMode.Unknown;
+        _clipboardText = null;
+        _clipboardHtml = null;
+        _clipboardRtf = null;
     }
 
     private void RichTextButton_Click(object sender, RoutedEventArgs e) => ConvertToRichText();

--- a/md2loop/MainWindow.xaml.cs
+++ b/md2loop/MainWindow.xaml.cs
@@ -37,6 +37,15 @@ public sealed partial class MainWindow : Window
 
         RootFrame.Navigate(typeof(MainPage));
 
+        Activated += (_, args) =>
+        {
+            if (args.WindowActivationState != WindowActivationState.Deactivated &&
+                RootFrame.Content is MainPage page)
+            {
+                page.OnWindowActivated();
+            }
+        };
+
         RootFrame.Loaded += (_, _) =>
         {
             // The rasterization scale is only trustworthy once the XAML tree is live;


### PR DESCRIPTION
Fixes #18

## Problem

`MainPage` started a `DispatcherTimer` on load and called `Clipboard.GetContent()` **once per second**, forever:

- It opened the clipboard constantly, competing with every other app that needs it. The Win32 clipboard is a single shared resource that only one process can hold at a time, so this is a common source of "clipboard is busy" failures elsewhere on the machine.
- It copied whatever the user had on the clipboard into this process every second, whether or not the user ever interacted with the app. If you copied a password out of a password manager, it landed in this app's memory too.

## Fix

**Event-driven reads.** The page subscribes to `Clipboard.ContentChanged` and reads once per real change, unsubscribing on unload. The handler marshals to the UI thread via `DispatcherQueue.TryEnqueue`, because the event is not guaranteed to arrive there.

**Activation fallback.** A desktop app does not reliably receive `ContentChanged` while it is in the background, which is exactly the normal case here (you copy in another app, then switch to this one). `MainWindow` now forwards `Activated` to the page, so the display is always refreshed when the window comes forward. Combined, these cover both the foreground and background cases with no timer.

**Privacy opt-out.** `ClipboardManager.ReadAsync` now returns a `ClipboardSnapshot` and first checks the two standard opt-out signals apps use to mark content sensitive:

- the `ExcludeClipboardContentFromMonitorProcessing` format, and
- the `CanIncludeInClipboardHistory` property set to `false`.

When either is present the content is **not read at all**, so secrets never enter this process, and the UI shows a distinct "Content is marked private" state rather than looking broken.

## Verification

- `dotnet build -c Release -r win-x64` - 0 warnings, 0 errors.
- Launched the built exe, changed the clipboard twice while it ran, and confirmed the app stayed alive and responsive with no crash from the event subscription or the UI-thread marshalling.
