### PR TITLE
Use clipboard change events and handle all clipboard failures

### DIFF
--- a/md2loop/ClipboardManager.cs
+++ b/md2loop/ClipboardManager.cs
@@ -22,7 +22,14 @@ public static class ClipboardManager
     private const string ExcludeFromMonitoringFormat = "ExcludeClipboardContentFromMonitorProcessing";
     private const string CanIncludeInHistoryProperty = "CanIncludeInClipboardHistory";
 
-    public static async Task<ClipboardSnapshot> ReadAsync()
+    /// <summary>
+    /// Reads the clipboard, returning <c>null</c> when it could not be read.
+    /// The clipboard is a shared, single-owner OS resource, so any access can
+    /// fail transiently; that is an expected outcome here rather than an error.
+    /// </summary>
+    public static Task<ClipboardSnapshot?> TryReadAsync() => TryAsync(ReadCoreAsync);
+
+    private static async Task<ClipboardSnapshot?> ReadCoreAsync()
     {
         var content = Clipboard.GetContent();
 
@@ -70,25 +77,77 @@ public static class ClipboardManager
 
     /// <summary>
     /// Writes converted content to clipboard with HTML + text for maximum Loop compatibility.
+    /// Returns false if the clipboard could not be written.
     /// </summary>
-    public static void WriteForLoop(string html, string markdown)
-    {
-        var dataPackage = new DataPackage();
-        dataPackage.SetHtmlFormat(HtmlFormatHelper.CreateHtmlFormat(html));
-        dataPackage.SetText(markdown);
-        Clipboard.SetContent(dataPackage);
-        Clipboard.Flush();
-    }
+    public static Task<bool> TryWriteForLoopAsync(string html, string markdown) =>
+        TryWriteAsync(() =>
+        {
+            var dataPackage = new DataPackage();
+            dataPackage.SetHtmlFormat(HtmlFormatHelper.CreateHtmlFormat(html));
+            dataPackage.SetText(markdown);
+            return dataPackage;
+        });
 
     /// <summary>
     /// Writes plain markdown text to clipboard.
+    /// Returns false if the clipboard could not be written.
     /// </summary>
-    public static void WriteMarkdown(string markdown)
+    public static Task<bool> TryWriteMarkdownAsync(string markdown) =>
+        TryWriteAsync(() =>
+        {
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(markdown);
+            return dataPackage;
+        });
+
+    private static async Task<bool> TryWriteAsync(Func<DataPackage> build)
     {
-        var dataPackage = new DataPackage();
-        dataPackage.SetText(markdown);
-        Clipboard.SetContent(dataPackage);
-        Clipboard.Flush();
+        var written = await TryRunAsync(() => Clipboard.SetContent(build()));
+
+        if (!written)
+            return false;
+
+        // Flush only makes the content outlive this process. If it fails the
+        // user still has the content, so a failure here is not reported.
+        await TryRunAsync(Clipboard.Flush);
+
+        return true;
     }
 
+    private static async Task<bool> TryRunAsync(Action operation)
+    {
+        var result = await TryAsync<bool>(() =>
+        {
+            operation();
+            return Task.FromResult<bool?>(true);
+        });
+
+        return result == true;
+    }
+
+    /// <summary>
+    /// Runs a clipboard operation, retrying briefly because another process may
+    /// hold the clipboard open, and returning <c>null</c> if it keeps failing.
+    /// Only clipboard interop runs in here, so this never hides an application bug.
+    /// </summary>
+    private static async Task<T?> TryAsync<T>(Func<Task<T?>> operation) where T : struct
+    {
+        const int attempts = 3;
+
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return await operation();
+            }
+            catch (Exception) when (attempt < attempts - 1)
+            {
+                await Task.Delay(40 * (attempt + 1));
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
 }

--- a/md2loop/ClipboardManager.cs
+++ b/md2loop/ClipboardManager.cs
@@ -3,13 +3,32 @@ using Windows.ApplicationModel.DataTransfer;
 namespace md2loop;
 
 /// <summary>
+/// A point-in-time view of the clipboard.
+/// </summary>
+public readonly record struct ClipboardSnapshot(string? Text, string? Html, string? Rtf, bool IsExcluded)
+{
+    /// <summary>
+    /// Content the source app asked monitoring tools not to process.
+    /// </summary>
+    public static ClipboardSnapshot Excluded { get; } = new(null, null, null, true);
+}
+
+/// <summary>
 /// Windows clipboard operations for reading and writing HTML/RTF/text content.
 /// </summary>
 public static class ClipboardManager
 {
-    public static async Task<(string? Text, string? Html, string? Rtf)> ReadAsync()
+    // Set by password managers and similar apps to opt out of clipboard monitoring.
+    private const string ExcludeFromMonitoringFormat = "ExcludeClipboardContentFromMonitorProcessing";
+    private const string CanIncludeInHistoryProperty = "CanIncludeInClipboardHistory";
+
+    public static async Task<ClipboardSnapshot> ReadAsync()
     {
         var content = Clipboard.GetContent();
+
+        if (IsExcludedFromMonitoring(content))
+            return ClipboardSnapshot.Excluded;
+
         string? text = null;
         string? html = null;
         string? rtf = null;
@@ -32,7 +51,21 @@ public static class ClipboardManager
             rtf = await content.GetRtfAsync();
         }
 
-        return (text, html, rtf);
+        return new ClipboardSnapshot(text, html, rtf, IsExcluded: false);
+    }
+
+    /// <summary>
+    /// Whether the source app marked the content as private. Such content is not
+    /// read at all, so passwords and similar secrets never enter this process.
+    /// </summary>
+    private static bool IsExcludedFromMonitoring(DataPackageView content)
+    {
+        if (content.Contains(ExcludeFromMonitoringFormat))
+            return true;
+
+        return content.Properties.TryGetValue(CanIncludeInHistoryProperty, out var value)
+            && value is bool canInclude
+            && !canInclude;
     }
 
     /// <summary>

--- a/md2loop/MainPage.xaml.cs
+++ b/md2loop/MainPage.xaml.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -77,17 +76,23 @@ public sealed partial class MainPage : Page
         _isReading = true;
         try
         {
-            var snapshot = await ClipboardManager.ReadAsync();
+            var snapshot = await ClipboardManager.TryReadAsync();
 
-            if (snapshot.IsExcluded)
+            if (snapshot is null)
+            {
+                ShowClipboardUnavailable();
+                return;
+            }
+
+            if (snapshot.Value.IsExcluded)
             {
                 ShowClipboardExcluded();
                 return;
             }
 
-            var text = snapshot.Text;
-            var html = snapshot.Html;
-            var rtf = snapshot.Rtf;
+            var text = snapshot.Value.Text;
+            var html = snapshot.Value.Html;
+            var rtf = snapshot.Value.Rtf;
 
             _clipboardText = text;
             _clipboardHtml = html;
@@ -123,14 +128,6 @@ public sealed partial class MainPage : Page
                     ShortcutText.Text = "Copy text or rich text to begin";
                     break;
             }
-        }
-        catch (COMException)
-        {
-            ShowClipboardUnavailable();
-        }
-        catch (UnauthorizedAccessException)
-        {
-            ShowClipboardUnavailable();
         }
         finally
         {
@@ -184,7 +181,7 @@ public sealed partial class MainPage : Page
             ShowFeedback("Clipboard has no convertible content", success: false);
     }
 
-    private void ConvertToRichText()
+    private async void ConvertToRichText()
     {
         if (string.IsNullOrWhiteSpace(_clipboardText))
         {
@@ -192,31 +189,44 @@ public sealed partial class MainPage : Page
             return;
         }
 
-        var html = LoopHtmlConverter.Convert(_clipboardText);
+        string html;
         try
         {
-            ClipboardManager.WriteForLoop(html, _clipboardText);
-            ShowFeedback("Rich text copied - ready for Loop", success: true);
+            html = LoopHtmlConverter.Convert(_clipboardText);
         }
-        catch (COMException)
+        catch (Exception)
         {
-            ShowFeedback("Clipboard is busy. Try again.", success: false);
+            ShowFeedback("Could not convert this content", success: false);
+            return;
         }
+
+        if (await ClipboardManager.TryWriteForLoopAsync(html, _clipboardText))
+            ShowFeedback("Rich text copied - ready for Loop", success: true);
+        else
+            ShowFeedback("Clipboard is busy. Try again.", success: false);
     }
 
-    private void ConvertToMarkdown()
+    private async void ConvertToMarkdown()
     {
         string? markdown = null;
 
-        if (!string.IsNullOrWhiteSpace(_clipboardHtml))
+        try
         {
-            markdown = HtmlToMarkdownConverter.Convert(_clipboardHtml);
-        }
+            if (!string.IsNullOrWhiteSpace(_clipboardHtml))
+            {
+                markdown = HtmlToMarkdownConverter.Convert(_clipboardHtml);
+            }
 
-        if (string.IsNullOrWhiteSpace(markdown) &&
-            RtfToMarkdownConverter.TryConvert(_clipboardRtf, out var rtfMarkdown))
+            if (string.IsNullOrWhiteSpace(markdown) &&
+                RtfToMarkdownConverter.TryConvert(_clipboardRtf, out var rtfMarkdown))
+            {
+                markdown = rtfMarkdown;
+            }
+        }
+        catch (Exception)
         {
-            markdown = rtfMarkdown;
+            ShowFeedback("Could not convert this content", success: false);
+            return;
         }
 
         if (string.IsNullOrWhiteSpace(markdown))
@@ -225,15 +235,10 @@ public sealed partial class MainPage : Page
             return;
         }
 
-        try
-        {
-            ClipboardManager.WriteMarkdown(markdown);
+        if (await ClipboardManager.TryWriteMarkdownAsync(markdown))
             ShowFeedback("Markdown copied", success: true);
-        }
-        catch (COMException)
-        {
+        else
             ShowFeedback("Clipboard is busy. Try again.", success: false);
-        }
     }
 
     private void ShowFeedback(string message, bool success)

--- a/md2loop/MainPage.xaml.cs
+++ b/md2loop/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -11,9 +12,9 @@ public sealed partial class MainPage : Page
     private string? _clipboardText;
     private string? _clipboardHtml;
     private string? _clipboardRtf;
-    private DispatcherTimer? _timer;
     private DispatcherTimer? _feedbackTimer;
-    private bool _isPolling;
+    private bool _isReading;
+    private bool _isSubscribed;
 
     public MainPage()
     {
@@ -34,33 +35,60 @@ public sealed partial class MainPage : Page
 
     private void Page_Loaded(object sender, RoutedEventArgs e)
     {
-        if (_timer is not null)
-            return;
+        if (!_isSubscribed)
+        {
+            Clipboard.ContentChanged += OnClipboardContentChanged;
+            _isSubscribed = true;
+        }
 
-        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        _timer.Tick += async (_, _) => await PollClipboardAsync();
-        _timer.Start();
-
-        _ = PollClipboardAsync();
+        _ = RefreshAsync();
     }
 
     private void Page_Unloaded(object sender, RoutedEventArgs e)
     {
-        _timer?.Stop();
-        _timer = null;
+        if (_isSubscribed)
+        {
+            Clipboard.ContentChanged -= OnClipboardContentChanged;
+            _isSubscribed = false;
+        }
+
         _feedbackTimer?.Stop();
         _feedbackTimer = null;
     }
 
-    private async Task PollClipboardAsync()
+    /// <summary>
+    /// Re-reads the clipboard when the window is activated. ContentChanged is not
+    /// always delivered to a desktop app that is not in the foreground, so this
+    /// covers changes made while another app had focus.
+    /// </summary>
+    public void OnWindowActivated() => _ = RefreshAsync();
+
+    private void OnClipboardContentChanged(object? sender, object e)
     {
-        if (_isPolling)
+        // The event does not necessarily arrive on the UI thread.
+        DispatcherQueue.TryEnqueue(() => _ = RefreshAsync());
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (_isReading)
             return;
 
-        _isPolling = true;
+        _isReading = true;
         try
         {
-            var (text, html, rtf) = await ClipboardManager.ReadAsync();
+            var snapshot = await ClipboardManager.ReadAsync();
+
+            if (snapshot.IsExcluded)
+            {
+                ShowClipboardExcluded();
+                return;
+            }
+
+            var text = snapshot.Text;
+            var html = snapshot.Html;
+            var rtf = snapshot.Rtf;
+
             _clipboardText = text;
             _clipboardHtml = html;
             _clipboardRtf = rtf;
@@ -106,23 +134,40 @@ public sealed partial class MainPage : Page
         }
         finally
         {
-            _isPolling = false;
+            _isReading = false;
         }
     }
 
     private void ShowClipboardUnavailable()
     {
-        _currentMode = ClipboardMode.Unknown;
-        _clipboardText = null;
-        _clipboardHtml = null;
-        _clipboardRtf = null;
+        ResetClipboardState();
         ClipboardLengthText.Text = "Unavailable";
         ModeIcon.Glyph = "\uE7BA";
         ModeIcon.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray);
         ModeText.Text = "Clipboard is temporarily busy";
-        ShortcutText.Text = "Will retry automatically";
+        ShortcutText.Text = "Copy again or reactivate the window";
         RichTextButton.IsEnabled = false;
         MarkdownButton.IsEnabled = false;
+    }
+
+    private void ShowClipboardExcluded()
+    {
+        ResetClipboardState();
+        ClipboardLengthText.Text = "Private";
+        ModeIcon.Glyph = "\uE72E"; // Lock
+        ModeIcon.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray);
+        ModeText.Text = "Content is marked private";
+        ShortcutText.Text = "This content was not read";
+        RichTextButton.IsEnabled = false;
+        MarkdownButton.IsEnabled = false;
+    }
+
+    private void ResetClipboardState()
+    {
+        _currentMode = ClipboardMode.Unknown;
+        _clipboardText = null;
+        _clipboardHtml = null;
+        _clipboardRtf = null;
     }
 
     private void RichTextButton_Click(object sender, RoutedEventArgs e) => ConvertToRichText();

--- a/md2loop/MainWindow.xaml.cs
+++ b/md2loop/MainWindow.xaml.cs
@@ -37,6 +37,15 @@ public sealed partial class MainWindow : Window
 
         RootFrame.Navigate(typeof(MainPage));
 
+        Activated += (_, args) =>
+        {
+            if (args.WindowActivationState != WindowActivationState.Deactivated &&
+                RootFrame.Content is MainPage page)
+            {
+                page.OnWindowActivated();
+            }
+        };
+
         RootFrame.Loaded += (_, _) =>
         {
             // The rasterization scale is only trustworthy once the XAML tree is live;


### PR DESCRIPTION
Combines the two clipboard PRs, since #38 was stacked on #37 and already contains both commits. Merging them separately caused the base-rewriting problem that made the earlier stacks unmergeable.

Closes #18
Closes #20

## Polling replaced with change events

The clipboard was polled once a second. That contends with other clipboard consumers and means the app continuously reads clipboard content it has no reason to see, including passwords and other sensitive data from unrelated applications. It now subscribes to `Clipboard.ContentChanged` instead.

## All clipboard failures handled

Only `COMException` was caught around clipboard access. The clipboard can fail in several other ways, most commonly when another process holds it open, and any of those crashed the app.

## Worth a careful look

`Clipboard.ContentChanged` is not reliably raised for an unpackaged WinUI 3 app while it is in the background, so there is a window-activation fallback that re-reads the clipboard when the app regains focus. The foreground path is verified; the specific case of the app sitting in the background for a long time was not exercised end to end, so that fallback is the part most worth reviewing.
