### PR TITLE
Add Copilot app repository configuration

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,3 @@
+automation:
+  auto_issue_session: true
+  remote_control: true


### PR DESCRIPTION
Adds the Copilot app repository configuration:

```yaml
automation:
  auto_issue_session: true
  remote_control: true
```

This file existed only as an uncommitted local file in a single clone, so the settings would have been lost the moment that clone was deleted. Committing it makes them part of the repo.

Note that this changes behaviour repo-wide rather than per-machine — `remote_control` and `auto_issue_session` now apply to the repository itself, which is the intent.

Content is byte-identical to the local original (blob `dec03bb6`).
