### PR TITLE
Keep the code language when stripping CSS classes

### DIFF
--- a/md2loop.Core/LoopHtmlConverter.cs
+++ b/md2loop.Core/LoopHtmlConverter.cs
@@ -2,13 +2,14 @@ using Markdig;
 using Markdig.Extensions.TaskLists;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
+using System.Text.RegularExpressions;
 
 namespace md2loop;
 
 /// <summary>
 /// Converts Markdown to Loop-optimized HTML (minimal, no CSS classes, Unicode checkboxes).
 /// </summary>
-public static class LoopHtmlConverter
+public static partial class LoopHtmlConverter
 {
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
@@ -39,11 +40,16 @@ public static class LoopHtmlConverter
 
         var html = writer.ToString();
 
-        // Remove CSS classes that Markdig adds
-        html = System.Text.RegularExpressions.Regex.Replace(html, @"\s*class=""[^""]*""", "");
+        // Remove the CSS classes Markdig adds, except the language-* hint on
+        // fenced code blocks: that is the only record of the code language, and
+        // dropping it means a round-trip back to Markdown loses it.
+        html = NonLanguageClassRegex().Replace(html, "");
 
         return html.Trim();
     }
+
+    [GeneratedRegex(@"\s*class=""(?!language-)[^""]*""")]
+    private static partial Regex NonLanguageClassRegex();
 
     private sealed class UnicodeTaskListRenderer : HtmlObjectRenderer<TaskList>
     {

--- a/tests/md2loop.Tests/LoopHtmlConverterTests.cs
+++ b/tests/md2loop.Tests/LoopHtmlConverterTests.cs
@@ -40,12 +40,24 @@ public class LoopHtmlConverterTests
         Assert.Contains("<th>a</th>", html);
     }
 
+    // Regression tests for #34. The class-stripping regex used to be blanket and
+    // removed language-*, which is the only record of a code block's language.
     [Fact]
-    public void Convert_StripsCssClasses()
+    public void Convert_KeepsTheCodeLanguageClass()
     {
         var html = LoopHtmlConverter.Convert("```csharp\nvar x = 1;\n```");
 
-        Assert.DoesNotContain("class=", html);
+        Assert.Contains("class=\"language-csharp\"", html);
+    }
+
+    [Fact]
+    public void Convert_StripsNonLanguageCssClasses()
+    {
+        // A custom container renders <div class="warning">, which Loop cannot use.
+        var html = LoopHtmlConverter.Convert(":::warning\nheads up\n:::");
+
+        Assert.DoesNotContain("class=\"warning\"", html);
+        Assert.Contains("heads up", html);
     }
 
     // Regression tests for #21. Markdig renders task lists as <input type="checkbox">,

--- a/tests/md2loop.Tests/RoundTripTests.cs
+++ b/tests/md2loop.Tests/RoundTripTests.cs
@@ -56,14 +56,6 @@ public class RoundTripTests
     }
 
     [Fact]
-    public void FencedCode_SurvivesARoundTrip_ExceptTheLanguage()
-    {
-        // The blanket class-stripping regex removes the language-* class that
-        // carries the code language, so the fence comes back bare. Tracked as #34.
-        Assert.Equal("```\nvar x = 1;\n```", RoundTrip("```csharp\nvar x = 1;\n```"));
-    }
-
-    [Fact(Skip = "Known bug #34: class stripping removes language-* from code blocks.")]
     public void FencedCode_KeepsItsLanguage()
     {
         Assert.Equal("```csharp\nvar x = 1;\n```", RoundTrip("```csharp\nvar x = 1;\n```"));


### PR DESCRIPTION
Fixes #34

Markdig records a fenced code block's language as `class="language-xxx"` on the `<code>` element. `LoopHtmlConverter` then stripped every class attribute with a blanket regex, which destroyed the only record of the language. A round-trip turned ` ```csharp ` back into a bare ` ``` `.

The HTML to Markdown direction already reads the `language-*` class correctly (that came in with the `<pre>` fix for #19), so the bug was entirely in the stripping step. The regex now skips class attributes whose value starts with `language-` and strips everything else, which is what Loop actually needs.

## Test changes worth a look

Un-skipping the round-trip test made two existing tests fail, both because they asserted the old buggy behaviour:

- `Convert_StripsCssClasses` asserted `class=` never appears in the output at all. Replaced with two narrower tests: one that the language class survives, one that a non-language class does not.
- `FencedCode_SurvivesARoundTrip_ExceptTheLanguage` expected the language to be lost. Removed, since `FencedCode_KeepsItsLanguage` now covers the same input with the correct expectation.

For the "non-language classes are still stripped" case I used a custom container (`:::warning`), because I wanted a class that Markdig genuinely emits rather than a guess. I verified the actual renderer output first: `:::warning` produces `<div class="warning">` before stripping and `<div>` after, so the assertion cannot pass vacuously.

## Verification

Full suite: **85 passed, 0 failed, 2 skipped**. The two remaining skips are the still-open bugs #32 and #33.

## Base branch

This targets `test/23-converter-tests` (PR #41) because the converters live in `md2loop.Core` and the test suite only exists on that branch. It needs to merge after #41.