### PR TITLE
Drop whitespace-only text nodes between block elements

### DIFF
--- a/md2loop.Core/HtmlToMarkdownConverter.cs
+++ b/md2loop.Core/HtmlToMarkdownConverter.cs
@@ -44,6 +44,15 @@ public static partial class HtmlToMarkdownConverter
             {
                 sb.Append(text);
             }
+            else if (text.AsSpan().IsWhiteSpace())
+            {
+                // Whitespace between block elements is layout, not content. A block
+                // ends with a newline, so a whitespace-only node there would become
+                // a stray leading space on the next block. Between inline elements
+                // the same node is a real word separator and has to be kept.
+                if (sb.Length > 0 && sb[^1] != '\n')
+                    sb.Append(' ');
+            }
             else
             {
                 sb.Append(EscapeInline(CollapseWhitespaceRegex().Replace(text, " ")));

--- a/tests/md2loop.Tests/RoundTripTests.cs
+++ b/tests/md2loop.Tests/RoundTripTests.cs
@@ -97,7 +97,7 @@ public class RoundTripTests
         Assert.Equal("- one\n- two\n\nAfter the list.", RoundTrip("- one\n- two\n\nAfter the list."));
     }
 
-    [Fact(Skip = "Known bug #33: whitespace between block elements leaks a leading space into the next block.")]
+    [Fact]
     public void WhitespaceBetweenBlocks_DoesNotIndentTheNextBlock()
     {
         Assert.Equal("one\n\ntwo", HtmlToMarkdownConverter.Convert("<p>one</p>\n<p>two</p>").Replace("\r\n", "\n"));


### PR DESCRIPTION
Fixes #33

Pretty-printed HTML puts a newline between block elements, and that newline is its own text node. It was collapsed to a single space and appended, so `<p>one</p>\n<p>two</p>` converted to `one\n\n two` with a stray leading space on the second block. Anything that pastes formatted HTML hits this, since almost every source indents its markup.

## The part that makes this non-trivial

The obvious fix, discarding whitespace-only text nodes, is wrong: between inline elements the very same node is a real word separator, so `<em>a</em> <em>b</em>` would become `*a**b*`.

The distinguishing signal turns out to already be in the output buffer. Every block element finishes by appending a newline, so if the buffer ends with a newline the whitespace is layout and can be dropped; otherwise it is inline and is kept as a single space. That also handles leading whitespace at the very start of a document, where the buffer is still empty.

## Verification

Full suite: **86 passed, 0 failed, 1 skipped**. The remaining skip is #32, which is still open. The inline-spacing cases are covered by the existing tests, which is what pinned down that the naive fix would have regressed them.

## Base branch

Stacked on `fix/34-code-block-language` (PR #51), which is itself stacked on the test project in PR #41. Merge order is #41, then #51, then this.
