### PR TITLE
Collapse redundant installer [Files] entries, stop shipping symbols

### DIFF
--- a/installer/md2loop.iss
+++ b/installer/md2loop.iss
@@ -56,12 +56,10 @@ Name: "startupentry"; Description: "Start md2loop with Windows"; GroupDescriptio
 
 [Files]
 Source: "..\publish\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\publish\*.dll"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
-Source: "..\publish\*.pri"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
-Source: "..\publish\*.winmd"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
-Source: "..\publish\*.json"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
-Source: "..\publish\Assets\*"; DestDir: "{app}\Assets"; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs
-Source: "..\publish\**"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs createallsubdirs; Excludes: "{#MyAppExeName}"
+; Catch-all for everything else a publish can produce (WinAppSDK native DLLs,
+; resources.pri, Assets\). A single-file publish leaves nothing but the exe and
+; the symbols behind, so this must tolerate matching no files at all.
+Source: "..\publish\**"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist recursesubdirs createallsubdirs; Excludes: "{#MyAppExeName},*.pdb"
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"


### PR DESCRIPTION
Fixes #24

The `[Files]` section listed `*.dll`, `*.pri`, `*.winmd`, `*.json` and `Assets\*` in front of a recursive `..\publish\**` catch-all that already matched every one of them, so it was impossible to tell whether the explicit entries were load-bearing.

## What the actual build showed

I ran `installer\build.ps1` locally with Inno Setup 6 to check before changing anything, and two of my assumptions were wrong in useful ways.

The issue predicts duplicate compression and inflated installer size. That does not happen. The release publish is single-file, so `publish\` contains only `md2loop.exe` and `md2loop.pdb`, and the five explicit patterns all fall through `skipifsourcedoesntexist` without matching anything. They are dead weight, not duplication.

What the build did surface is a real problem the issue does not mention: the catch-all was packaging `md2loop.pdb`, so **every installer shipped debug symbols to end users**. That is now excluded.

The other correction is that `skipifsourcedoesntexist` on the catch-all is load-bearing and cannot be dropped as the issue suggests. Once the exe and the symbols are excluded, the pattern legitimately matches nothing on a single-file publish and ISCC fails the compile without it.

## Verification

Both against a real `dotnet publish` output, not a dry run.

| | before | after |
|---|---|---|
| files compressed | `md2loop.exe`, `md2loop.pdb` | `md2loop.exe` |
| installer size | 87.93 MB | 87.88 MB |
| compile time | 77.8 s | 55.0 s |

To confirm the catch-all still covers what the deleted lines claimed to, I dropped stand-in `Microsoft.WindowsAppRuntime.Bootstrap.dll`, `resources.pri`, `md2loop.deps.json` and `Assets\Square150x150Logo.png` into `publish\` and recompiled. All four are picked up, and `Assets\` keeps its subdirectory through `recursesubdirs createallsubdirs`. So a future non-single-file publish is still packaged correctly.
