### PR TITLE
Give the portable ZIP one versioned name in both build paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,19 @@ jobs:
 
       - name: Create portable ZIP
         run: |
-          Compress-Archive -Path publish/* -DestinationPath dist/md2loop-${{ matrix.rid }}.zip
+          # The installer step happens to create dist/ via the .iss OutputDir, but
+          # relying on that would break this step the moment the installer is
+          # skipped or reordered.
+          New-Item -ItemType Directory -Path dist -Force | Out-Null
+          $version = "${{ steps.version.outputs.VERSION }}"
+          Compress-Archive -Path publish/* -DestinationPath "dist/md2loop-$version-${{ matrix.rid }}.zip"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: md2loop-${{ matrix.rid }}
           path: |
-            dist/md2loop-${{ matrix.rid }}.zip
+            dist/md2loop-*.zip
             dist/md2loop-setup-*.exe
 
   release:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Grab the latest release from the [Releases page](https://github.com/trsdn/md2loo
 |------|-------------|
 | `md2loop-setup-x.y.z-win-x64.exe` | **Installer** — Intel/AMD 64-bit |
 | `md2loop-setup-x.y.z-win-arm64.exe` | **Installer** — ARM64 (Surface Pro, Snapdragon) |
-| `md2loop-win-x64.zip` | Portable ZIP (Intel/AMD 64-bit) |
-| `md2loop-win-arm64.zip` | Portable ZIP (ARM64 — Surface Pro, Snapdragon) |
+| `md2loop-x.y.z-win-x64.zip` | Portable ZIP (Intel/AMD 64-bit) |
+| `md2loop-x.y.z-win-arm64.zip` | Portable ZIP (ARM64 — Surface Pro, Snapdragon) |
 
 The installer handles everything — just run it. No .NET runtime needed.
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -73,7 +73,7 @@ if (-not (Test-Path $iscc)) {
 }
 
 # Also create portable ZIP
-$zipPath = "$distDir\md2loop-win-$Architecture-v$Version.zip"
+$zipPath = "$distDir\md2loop-$Version-win-$Architecture.zip"
 Compress-Archive -Path "$publishDir\*" -DestinationPath $zipPath
 Write-Host ""
 Write-Host "✅ Build complete!" -ForegroundColor Green


### PR DESCRIPTION
Fixes #26

`installer/build.ps1` produced `md2loop-win-x64-v1.2.3.zip` while `release.yml` produced `md2loop-win-x64.zip`. A local build could not reproduce a release artifact, and the published ZIP carried no version at all, so a downloaded `md2loop-win-x64.zip` was unidentifiable and successive releases collided in a downloads folder.

Both now emit `md2loop-<version>-<rid>.zip`, which matches the shape the installer already used (`md2loop-setup-<version>-<rid>.exe`).

## The latent bug I found next to it

The ZIP step ran `Compress-Archive -DestinationPath dist/...` without anything creating `dist/`. It works today purely by accident: the preceding Inno Setup step creates the directory through the `.iss` `OutputDir`. Skipping the installer, reordering the steps, or a future matrix entry that does not build an installer would have broken the release at tag time. `dist/` is now created explicitly.

The artifact upload path is also widened from the hardcoded old filename to `dist/md2loop-*.zip`. The `release` job globs `artifacts/md2loop-win-<arch>/*.zip`, so it keeps working unchanged.

## Verification

`release.yml` cannot be exercised outside a `v*` tag push, so I checked it two ways: parsed the file to confirm the step list and the new upload paths survive YAML round-tripping, and ran `installer\build.ps1 -Architecture x64 -Version 9.9.9` end to end with Inno Setup locally. It produced exactly:

```
md2loop-9.9.9-win-x64.zip
md2loop-setup-9.9.9-win-x64.exe
```

README download table updated to match.
